### PR TITLE
Avoid excessive escaping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,6 @@ jobs:
           - '82'
           - '81'
           - '80'
-          - '74'
-          - '73'
-          - '72'
 
     # Remove this line if GitHub Actions is your preferred means of running the tests.
     # if: ${{ false }}

--- a/report.php
+++ b/report.php
@@ -76,7 +76,7 @@ $message = trim( exec('git --git-dir=' . escapeshellarg( $WPT_PREPARE_DIR ) . '/
  * safely used in shell commands.
  */
 log_message('Copying junit.xml results');
-$junit_location = escapeshellarg( $WPT_TEST_DIR ) . '/tests/phpunit/build/logs/*';
+$junit_location = $WPT_TEST_DIR . '/tests/phpunit/build/logs/*';
 
 /**
  * Modifies the junit.xml results file path for a remote location if an SSH connection is available.
@@ -86,7 +86,7 @@ $junit_location = escapeshellarg( $WPT_TEST_DIR ) . '/tests/phpunit/build/logs/*
  * remote path to ensure that the junit.xml results can be accessed or copied over SSH.
  */
 if ( ! empty( $WPT_SSH_CONNECT ) ) {
-	$junit_location = '-e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( $WPT_SSH_CONNECT . ':' . $junit_location );
+	$junit_location = '-e "ssh ' . $WPT_SSH_OPTIONS . '" ' . escapeshellarg( $WPT_SSH_CONNECT ) . ':' . escapeshellarg( $junit_location );
 }
 
 /**

--- a/test.php
+++ b/test.php
@@ -70,13 +70,15 @@ unset( $WPT_EXTRATESTS_INI );
  * avoid reporting useless tests.
  */
 $WPT_PHPUNIT_CMD = trim( getenv( 'WPT_PHPUNIT_CMD' ) );
-if( empty( $WPT_PHPUNIT_CMD ) ) {
-	$WPT_PHPUNIT_CMD = 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . ' && ' . $WPT_PHP_EXECUTABLE . ' ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests' . $WPT_FLAVOR_TXT . $WPT_EXTRATESTS_TXT;
+if ( empty( $WPT_PHPUNIT_CMD ) ) {
+	$WPT_PHPUNIT_CMD = escapeshellarg( 'cd ' . $WPT_TEST_DIR . ' && ' . $WPT_PHP_EXECUTABLE . ' ./vendor/phpunit/phpunit/phpunit --dont-report-useless-tests' . $WPT_FLAVOR_TXT . $WPT_EXTRATESTS_TXT );
+} else {
+	$WPT_PHPUNIT_CMD = escapeshellarg( $WPT_PHPUNIT_CMD );
 }
 
 // If an SSH connection string is provided, prepend the SSH command to the PHPUnit execution command.
 if ( ! empty( $WPT_SSH_CONNECT ) ) {
-	$WPT_PHPUNIT_CMD = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $WPT_PHPUNIT_CMD );
+	$WPT_PHPUNIT_CMD = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . $WPT_PHPUNIT_CMD;
 }
 
 // Execute the PHPUnit command.


### PR DESCRIPTION
## Proposed changes

When an SSH connection is configured for the runner, the `$junit_location` is passed through `escapeshellarg()` twice. This results in a the following error:

`rsync: [sender] change_dir "/home4/USERNAME/'wp-test-runner-80'/tests/phpunit/build/logs" failed: No such file or directory (2)`

The actual command that's run is `rsync -r -e "ssh " 'USERNAME@HOST:'\''wp-test-runner-80'\''/tests/phpunit/build/logs/*' '/tmp/wp-test-runner'`. Note the excessive single quotations in the path.

[Here is an example in the GitHub Actions log output](https://github.com/newfold-labs/wp-test-runner-bluehost/actions/runs/17226982062/job/48873498276#step:7:23).

This also removes PHP 7.x jobs from the test matrix. Our new boxes do not come with those versions available.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->