### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo.
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   # Tests the PHPUnit test runner.
   #
@@ -43,6 +47,8 @@ jobs:
   test:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 1 (`tests.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `f453a4e` |
| Timeouts commit | `3ad6c03` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `tests.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| tests.yml | 1 job was missing a scoped `permissions:` directive | test | `contents: read` [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| tests.yml | test | `30` | Matrix job runs checkout, PHP/Node setup, prepare, tests, report, and cleanup across several PHP versions; 30 minutes caps runaway usage while allowing a typical scheduled run to complete under normal conditions. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | **Glob verification:** Workflow YAML files matching `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-test-runner-bluehost/.github/workflows/*.yml` — **1 file:** `.github/workflows/tests.yml`. |
| 2 | No steps use `actions/github-script`, `gh`, Octokit, or explicit GitHub REST calls beyond standard pinned third-party actions (`actions/checkout`, `shivammathur/setup-php`, `actions/setup-node`); least-privilege assessment assumes only repository checkout requires token-backed Git access (`contents: read`). |


